### PR TITLE
#34 Fix `nix profile upgrade` command & add profile path detection

### DIFF
--- a/src/steps/os/unix.rs
+++ b/src/steps/os/unix.rs
@@ -277,6 +277,7 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
     let nix = require("nix")?;
     let nix_channel = require("nix-channel")?;
     let nix_env = require("nix-env")?;
+    let manifest_json_path: &str = "/nix/var/nix/profiles/per-user/manu/profile/manifest.json".into();
 
     let output = Command::new(&nix_env).args(&["--query", "nix"]).check_output();
     debug!("nix-env output: {:?}", output);
@@ -317,7 +318,12 @@ pub fn run_nix(ctx: &ExecutionContext) -> Result<()> {
     }
 
     run_type.execute(&nix_channel).arg("--update").check_run()?;
-    run_type.execute(&nix_env).arg("--upgrade").check_run()
+
+    if std::path::Path::new(&manifest_json_path).exists() {
+        run_type.execute(&nix).arg("profile upgrade '.*'").check_run()
+    } else {
+        run_type.execute(&nix_env).arg("--upgrade").check_run()
+    }
 }
 
 pub fn run_yadm(ctx: &ExecutionContext) -> Result<()> {

--- a/src/steps/zsh.rs
+++ b/src/steps/zsh.rs
@@ -47,7 +47,7 @@ pub fn run_antigen(base_dirs: &BaseDirs, run_type: RunType) -> Result<()> {
 
     print_separator("antigen");
 
-    let cmd = format!("source {} && antigen selfupdate && antigen update", zshrc.display());
+    let cmd = format!("source {} && (antigen selfupdate ; antigen update)", zshrc.display());
     run_type.execute(zsh).args(&["-l", "-c", cmd.as_str()]).check_run()
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/topgrade-rs/topgrade/issues/34#issuecomment-1287423589

- [x] The PR title is descriptive.
- [x] The code compiles (`cargo build`)
- [x] The code passes rustfmt (`cargo fmt`)
- [ ] The code passes clippy (`cargo clippy`) - nope
- [x] The code passes tests (`cargo test`)
- [x] *Optional:* I have tested the code myself
    - [x] I also tested that Topgrade skips the step where needed
